### PR TITLE
Adds on-open action

### DIFF
--- a/addon/components/searchable-select.js
+++ b/addon/components/searchable-select.js
@@ -57,6 +57,7 @@ export default Ember.Component.extend({
   'on-add': null,
   'on-search': null,
   'on-close': null,
+  'on-open': null,
 
   // Make the passed in `selected` a one-way binding.
   // `Ember.computed.oneWay` won't pick up on upstream
@@ -267,6 +268,8 @@ export default Ember.Component.extend({
     },
     showMenu() {
       this.set('_isShowingMenu', true);
+
+      this.checkForFunction(this.get('on-open')).call(this);
 
       Ember.run.scheduleOnce('afterRender', this, function() {
         // focus search input

--- a/index.js
+++ b/index.js
@@ -2,8 +2,5 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-searchable-select',
-isDevelopingAddon: function() {
-  return true;
-}
+  name: 'ember-searchable-select'
 };

--- a/index.js
+++ b/index.js
@@ -2,5 +2,8 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-searchable-select'
+  name: 'ember-searchable-select',
+isDevelopingAddon: function() {
+  return true;
+}
 };

--- a/tests/dummy/app/pods/components/options-table/template.hbs
+++ b/tests/dummy/app/pods/components/options-table/template.hbs
@@ -22,6 +22,7 @@
     on-search                 | Specify your own named action to trigger when the search text  changes. eg. <code>(action "search")</code>The search text is sent as an argument. Useful for custom filtering or AJAX search. The component's internal filter is automatically disabled when an on-search action is provided.     | Ember action    | null
     isLoading                 | Pass in your own boolean flag to toggle visibility of a loading animation.     | boolean     | false
     loadingMessage            | Text to displayed beside the loading animation when `isLoading` is true.    | string    | 'Searching...'
+    on-open                  | Specify your own named action to trigger when the menu opens. Useful if you opt not to auto close the menu when a selection is made and you'd like to hold off on propagating changes until the menu closes. | Ember action | null
     on-close                  | Specify your own named action to trigger when the menu closes. Useful hook for clearing out content that was previously passed in with AJAX. | Ember action | null
 
 

--- a/tests/integration/components/searchable-select-test.js
+++ b/tests/integration/components/searchable-select-test.js
@@ -233,12 +233,15 @@ test(
 );
 
 test('selection gets passed out with the on-change action', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
   this.set('content', TEDevents);
 
   let itemToSelect = TEDevents.findBy('title', 'TEDGlobal 2014');
 
   this.actions = {
+    assertOpened() {
+      assert.ok('action dispacted for menu open event');
+    },
     assertChanged(selection) {
       assert.deepEqual(selection, itemToSelect);
     },
@@ -250,6 +253,7 @@ test('selection gets passed out with the on-change action', function(assert) {
   this.render(hbs`{{searchable-select
     content=content
     on-change=(action "assertChanged")
+    on-open=(action 'assertOpened')
     on-close=(action "assertClosed")}}`);
 
   this.$('.Searchable-select__label').click();


### PR DESCRIPTION
This is useful for cases when you've opted not to auto-close the menu when a selection is made, and need to hold back on propagating changes out until the menu is closed. 

eg. use in conjunction with `on-change` and `on-close` actions:

```js
//template.hbs
{{serachable-select
  content=framingTags
  on-change=(action 'didUpdateFramingTags')
  on-open=(action 'framingMenuDidOpen')
  on-close=(action 'framingMenuDidClose') }}
```
```js
//component.js 

newFramingTags, null,
actions: {
  framingMenuDidOpen(){
    this.set('isFramingMenuOpen', true);
  },    
  didUpdateFramingTags(tags) {
    this.set('newFramingTags', tags);  
  },
  framingMenuDidClose(){
    this.set('isFramingMenuOpen', false);
      
    if (this.get('newFramingTags')) {
      // persist changes 
    }
  },
  selectCameraTag(category, cameraTag) {
    this.attrs.selectCameraTags(category, [cameraTag]);
  }
}
```
