### PR TITLE
Migrate to use Array.includes from .contains

### DIFF
--- a/addon/components/searchable-select-option.js
+++ b/addon/components/searchable-select-option.js
@@ -24,7 +24,7 @@ export default Ember.Component.extend({
   }),
   isSelected: Ember.computed('option', 'selected', 'selected.[]', function() {
     if (Array.isArray(this.get('selected'))) {
-      return Ember.A(this.get('selected')).contains(this.get('option'));
+      return Ember.A(this.get('selected')).includes(this.get('option'));
     } else {
       return this.get('selected') === this.get('option');
     }

--- a/addon/components/searchable-select.js
+++ b/addon/components/searchable-select.js
@@ -206,7 +206,7 @@ export default Ember.Component.extend({
   _toggleSelection(item) {
     if (item === null) {
       this.set('_selected', Ember.A([]));
-    } else if (Ember.A(this.get('_selected')).contains(item)) {
+    } else if (Ember.A(this.get('_selected')).includes(item)) {
       this.removeFromSelected(item);
     } else {
       this.addToSelected(item);


### PR DESCRIPTION
This is required as .contains seems to be deprecated in ember-3.

See https://github.com/emberjs/ember.js/pull/13553 for more information